### PR TITLE
Add support for using the string in an environment variable as the SSL cert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,7 @@ docs/_build/
 target/
 
 node_modules/
+
+# App specific
+.cert.pem
+.htpasswd

--- a/lmod_proxy/config.py
+++ b/lmod_proxy/config.py
@@ -20,6 +20,12 @@ CONFIG_KEYS = {
     # combined file
     'LMODP_CERT': 'ocw.app.mit.edu-key-and-cert.pem',
 
+    # The base64 encoded string of the certificate as opposed to the
+    # path. This will trigger the app to write out the certificate on
+    # startup for environments that are best configured via variables
+    # only like Heroku.
+    'LMODP_CERT_STRING': '',
+
     # Base URL for which the gradebook API lives and accepts
     # certificate authentication
     'LMODP_URLBASE': 'https://learning-modules.mit.edu:8443/',
@@ -55,9 +61,14 @@ def _configure():
         )
 
     if configuration['LMODP_HTPASSWD']:
-        configuration['LMOD_HTPASSWD_PATH'] = os.path.abspath('.htpasswd')
-        with open(configuration['LMOD_HTPASSWD_PATH'], 'w') as wfile:
+        configuration['LMODP_HTPASSWD_PATH'] = os.path.abspath('.htpasswd')
+        with open(configuration['LMODP_HTPASSWD_PATH'], 'w') as wfile:
             wfile.write(configuration['LMODP_HTPASSWD'])
+
+    if configuration['LMODP_CERT_STRING']:
+        configuration['LMODP_CERT'] = os.path.abspath('.cert.pem')
+        with open(configuration['LMODP_CERT'], 'w') as wfile:
+            wfile.write(configuration['LMODP_CERT_STRING'])
 
     return configuration
 

--- a/lmod_proxy/tests/test_config.py
+++ b/lmod_proxy/tests/test_config.py
@@ -96,5 +96,26 @@ class TestConfiguration(unittest.TestCase):
 
             self.assertEqual(
                 lmod_proxy.config._configure()['LMODP_HTPASSWD_PATH'],
-                '.htpasswd'
+                os.path.abspath('.htpasswd')
+            )
+
+    def test_cert_string_to_file(self):
+        """Verify we can turn an LMODP_CERT_STRING env variable to a file"""
+        self.addCleanup(os.remove, '.cert.pem')
+
+        cert_string = 'hello cert!'
+        with mock.patch.dict(
+            'os.environ', {'LMODP_CERT_STRING': cert_string}, clear=True
+        ):
+            import lmod_proxy.config
+            # Reload to reinitialize CONFIG_KEYS with patched environ
+            imp.reload(lmod_proxy.config)
+            self.assertTrue(os.path.isfile('.cert.pem'))
+
+            with open('.cert.pem') as cert_file:
+                self.assertEqual(cert_string, cert_file.read())
+
+            self.assertEqual(
+                lmod_proxy.config._configure()['LMODP_CERT'],
+                os.path.abspath('.cert.pem')
             )


### PR DESCRIPTION
This also fixed a bug in this working properly for the htpasswd file
closes #19