### PR TITLE
Use proper multipart form type for ``datafile`` field in form

### DIFF
--- a/lmod_proxy/config.py
+++ b/lmod_proxy/config.py
@@ -41,6 +41,9 @@ CONFIG_KEYS = {
 
     # Logging level
     'FLASK_LOG_LEVEL': 'INFO',
+
+    # Disable WTF CSRF protection
+    'WTF_CSRF_ENABLED': False,
 }
 
 

--- a/lmod_proxy/edx_grades/__init__.py
+++ b/lmod_proxy/edx_grades/__init__.py
@@ -39,10 +39,11 @@ def index(user):
         requestor = request.headers.getlist("X-Forwarded-For")[0]
 
     if request.method == 'POST':
-        form = EdXGradesForm(request.form)
+        form = EdXGradesForm()
         log.info('edX remote gradebook POST request from %s', requestor)
-        log.debug('POST data: {0}'.format(request.form))
-        log.debug('Form values: {0}'.format(form.data))
+        log.debug('Headers: %r', request.headers)
+        log.debug('POST data: %r', request.form)
+        log.debug('Form values: %r', form.data)
         if form.validate():
             message, data, success = ACTIONS[form.submit.data](
                 GradeBook(

--- a/lmod_proxy/edx_grades/actions.py
+++ b/lmod_proxy/edx_grades/actions.py
@@ -1,12 +1,14 @@
 # -*- coding: utf-8 -*-
 """Actions to perform based on API request.
 """
-from cStringIO import StringIO
+import logging
 
 from flask import render_template, current_app
 from requests.exceptions import RequestException
 
 from pylmod.exceptions import PyLmodException
+
+log = logging.getLogger(__name__)
 
 
 def post_grades(gradebook, form):
@@ -22,12 +24,14 @@ def post_grades(gradebook, form):
     approve_grades = False
     if current_app.config['LMODP_APPROVE_GRADES']:
         approve_grades = True
-
-    fake_csv = StringIO(form.datafile.data)
+    csv_file = form.datafile.data.stream
+    log.debug('Received grade CSV: %s', csv_file.read())
+    # Seek back to 0 for future reading
+    csv_file.seek(0)
     results = None
     try:
         results, time_taken = gradebook.spreadsheet2gradebook(
-            csv_file=fake_csv, approve_grades=approve_grades
+            csv_file=csv_file, approve_grades=approve_grades
         )
     except PyLmodException, ex:
         error_message = unicode(ex)

--- a/lmod_proxy/edx_grades/forms.py
+++ b/lmod_proxy/edx_grades/forms.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """Forms needed for the edx_grade blueprint."""
-from wtforms import Form, SelectField, StringField, validators
+from flask_wtf import Form
+from flask_wtf.file import FileField
+from wtforms import SelectField, StringField, validators
 
 from lmod_proxy.edx_grades.actions import (
     post_grades,
@@ -31,8 +33,9 @@ class EdXGradesForm(Form):
     """Form given to us by edx-platform."""
     gradebook = StrippedField(validators=[validators.required()])
     user = StrippedField(id=u'user', validators=[validators.Email()])
-    datafile = StrippedField(
-        id=u'datafile', validators=[validators.Optional()]
+    datafile = FileField(
+        id=u'datafile',
+        validators=[validators.Optional()]
     )
     section = StrippedField(id=u'section', validators=[validators.Optional()])
     submit = SelectField(

--- a/lmod_proxy/edx_grades/templates/edx_grades/grade_transfer_failed.html
+++ b/lmod_proxy/edx_grades/templates/edx_grades/grade_transfer_failed.html
@@ -6,4 +6,5 @@
   <li>
     {{ grade }}
   </li>
+  {% endfor %}
 </ul>

--- a/lmod_proxy/edx_grades/templates/edx_grades/grade_transfer_failed.html
+++ b/lmod_proxy/edx_grades/templates/edx_grades/grade_transfer_failed.html
@@ -1,10 +1,6 @@
-<p>
-  {{ number_failed }} of grades failed to transfer
-</p>
-<ul>
-  {% for grade in failed_grades %}
-  <li>
-    {{ grade }}
-  </li>
-  {% endfor %}
-</ul>
+{{ number_failed }} grade{% if number_failed > 1 %}s{% endif %} failed to transfer
+{% for grade in failed_grades %}
+  {% if grade['status'] == -1 %}
+    {{ grade['message'] }}
+  {% endif %}
+{% endfor %}

--- a/lmod_proxy/static/site/js/site.js
+++ b/lmod_proxy/static/site/js/site.js
@@ -16,7 +16,13 @@ $(document).ready(function(){
 
   function post_call(data) {
     $('#error').hide(100);
-    $.post(location.pathname, data)
+    $.ajax({
+      url: location.pathname, 
+      data: data,
+      type: 'POST',
+      processData: false,
+      contentType: false
+    })
       .done(function(data, status){
         $('#result-msg').html(data['msg']); 
 
@@ -70,56 +76,52 @@ $(document).ready(function(){
 
   // Submit form handling
   $('#get-membership').click(function(event){
-    post_call({
-      'gradebook': $('#gradebook').val(),
-      'user': $('#user').val(),
-      'section': $('#section').val(),
-      'submit': 'get-membership',
-    });
+    form_data = new FormData();
+    form_data.append('gradebook', $('#gradebook').val());
+    form_data.append('user', $('#user').val());
+    form_data.append('section', $('#section').val());
+    form_data.append('submit', 'get-membership')
+    post_call(form_data)
     event.preventDefault();
   });
 
   $('#get-assignments').click(function(event){
-    post_call({
-      'gradebook': $('#gradebook').val(),
-      'user': $('#user').val(),
-      'section': $('#section').val(),
-      'submit': 'get-assignments',
-    });
+    form_data = new FormData();
+    form_data.append('gradebook', $('#gradebook').val());
+    form_data.append('user', $('#user').val());
+    form_data.append('section', $('#section').val());
+    form_data.append('submit', 'get-assignments')
+    post_call(form_data)
     event.preventDefault();
   });
 
   $('#get-sections').click(function(event){
-    post_call({
-      'gradebook': $('#gradebook').val(),
-      'user': $('#user').val(),
-      'section': $('#section').val(),
-      'submit': 'get-sections',
-    });
+    form_data = new FormData();
+    form_data.append('gradebook', $('#gradebook').val());
+    form_data.append('user', $('#user').val());
+    form_data.append('section', $('#section').val());
+    form_data.append('submit', 'get-sections')
+    post_call(form_data)
     event.preventDefault();
   });
 
   $('#post-grades').click(function(event){
     var file = $('#datafile').prop('files')[0];
     if(typeof file === "undefined") {
-        $('#error').html(
-          '<p>CSV file is required for <em>Post Grades</em></p>'
-        );
-        $('#error').show(500);      
+      $('#error').html(
+        '<p>CSV file is required for <em>Post Grades</em></p>'
+      );
+      $('#error').show(500);
+      event.preventDefault();
+      return;
     }
-    var datafile = ''
-    file_reader = new FileReader();
-    file_reader.onload = function() {
-      datafile = file_reader.result;
-      post_call({
-        'gradebook': $('#gradebook').val(),
-        'user': $('#user').val(),
-        'section': $('#section').val(),
-        'datafile': datafile,
-        'submit': 'post-grades',
-      });
-    }
-    file_reader.readAsText(file);
+    form_data = new FormData();
+    form_data.append('gradebook', $('#gradebook').val());
+    form_data.append('user', $('#user').val());
+    form_data.append('section', $('#section').val());
+    form_data.append('datafile', file);
+    form_data.append('submit', 'post-grades')
+    post_call(form_data)
     event.preventDefault();
   });
 

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
         'pylmod',
         'PyYAML',
         'uwsgi',
-        'WTForms',
+        'Flask-WTF',
     ],
     entry_points={'console_scripts': [
         'lmod_proxy = lmod_proxy.cmd:run_server',


### PR DESCRIPTION
This is dependent on #26 on accident, but due to how extensive the modifications are here, it was too difficult to pull apart.  Once that merges, this should be cleaner to review.

It turns out what I thought was a fake CSV file in string form from the platform is in fact a real File form.  We just weren't actually posting grades through the platform all this time.  This corrects that major bug.