### PR TITLE
Updated build for new imported library features

### DIFF
--- a/lmod_proxy/tests/test_edx_grades.py
+++ b/lmod_proxy/tests/test_edx_grades.py
@@ -84,7 +84,7 @@ class TestEdXGrades(CommonTest):
             for key, item in form.data.items():
                 self.assertEqual(self.FULL_FORM[key], item)
 
-    @mock.patch('lmod_proxy.edx_grades.log')
+    @mock.patch('lmod_proxy.edx_grades.log', autospec=True)
     def test_get_root(self, log):
         """Test the GET response returns what we want"""
         headers = self.get_basic_auth_headers()
@@ -94,7 +94,7 @@ class TestEdXGrades(CommonTest):
             headers=headers
         )
         self.assertEqual(200, response.status_code)
-        log.info.assert_assert_called_with(
+        log.info.assert_called_with(
             'edX remote gradebook GET request from %s',
             'abc'
         )
@@ -119,7 +119,7 @@ class TestEdXGrades(CommonTest):
             }
         )
 
-    @mock.patch('lmod_proxy.edx_grades.GradeBook')
+    @mock.patch('lmod_proxy.edx_grades.GradeBook', autospec=True)
     def test_post_actions(self, patched_gradebook):
         """Verify that we call the right functions with each action type"""
         local_form = copy.deepcopy(self.FULL_FORM)
@@ -227,7 +227,7 @@ class TestEdXGrades(CommonTest):
         self.assertEqual(message, 'test')
         self.assertEqual(data, [{}])
 
-    @mock.patch('lmod_proxy.edx_grades.actions.log')
+    @mock.patch('lmod_proxy.edx_grades.actions.log', autospec=True)
     def test_post_grades(self, mock_log):
         """Test post_grades actions as expected"""
         from lmod_proxy.edx_grades.forms import EdXGradesForm
@@ -274,7 +274,8 @@ class TestEdXGrades(CommonTest):
 
         with self.app.app_context():
             with mock.patch(
-                    'lmod_proxy.edx_grades.actions.render_template'
+                    'lmod_proxy.edx_grades.actions.render_template',
+                    autospec=True
             ) as mock_template:
                 message, data, success = post_grades(gradebook, form)
 

--- a/lmod_proxy/tests/test_module.py
+++ b/lmod_proxy/tests/test_module.py
@@ -29,13 +29,16 @@ class TestModule(unittest.TestCase):
 
         error_string = 'Please install this project with setup.py'
 
-        with mock.patch('lmod_proxy.get_distribution') as mock_distribution:
+        with mock.patch(
+                'lmod_proxy.get_distribution',
+                autospec=True
+        ) as mock_distribution:
             # Test with distribution not found:
             mock_distribution.side_effect = DistributionNotFound()
             self.assertEqual(_get_version(), error_string)
 
         # Test with loc path not matching
-        with mock.patch('os.path.abspath') as mock_path:
+        with mock.patch('os.path.abspath', autospec=True) as mock_path:
             mock_path.return_value = 'not/where/we/are'
             self.assertEqual(_get_version(), error_string)
             # Bonus regression test to make sure we are calling

--- a/lmod_proxy/tests/test_web.py
+++ b/lmod_proxy/tests/test_web.py
@@ -46,7 +46,7 @@ class TestWeb(CommonTest):
         imp.reload(lmod_proxy.config)
         import lmod_proxy.web
 
-        with mock.patch('lmod_proxy.web.log') as patch_log:
+        with mock.patch('lmod_proxy.web.log', autospec=True) as patch_log:
             local_app = lmod_proxy.web.app_factory()
             self.assertTrue(patch_log.critical.called)
             self.assertEqual(

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ flask-log==0.1.0
 passlib==1.6.2
 pylmod==0.1.0
 PyYAML==3.11
+setuptools>=17.1
 uwsgi==2.0.10
- 
+
 -e .

--- a/setup.py
+++ b/setup.py
@@ -43,10 +43,7 @@ class PyTest(testcommand):
         import pytest
         # Needed in order for pytest_cache to load properly
         # Alternate fix: import pytest_cache and pass to pytest.main
-        import _pytest.config
 
-        pm = _pytest.config.get_plugin_manager()
-        pm.consider_setuptools_entrypoints()
         errno = pytest.main(self.test_args)
         sys.exit(errno)
 

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,8 +1,9 @@
-pytest-cov>=1.8.0
-pytest-pep8>=1.0.6,
-pytest-flakes>=0.2,
-pytest>=2.6.3,
-pyflakes>=0.8.1,
-pytest-cache>=1.0,
-semantic_version>=2.3.1
-mock>=1.0.1
+mock==1.0.1
+pyflakes==0.8.1
+pytest-cache==1.0
+pytest-cov==1.8.0
+pytest-flakes==0.2
+pytest-pep8==1.0.6
+pytest==2.6.4
+semantic_version==2.3.1
+setuptools>=17.1


### PR DESCRIPTION
Mock used to let you call any method, real or imagined, on a
mock object.  That feature allowed you to call any method name,
real or imagined, on the mock object. Adding the ``autospec=True``
flag causes mock to check whether the method is actually defined.
Adding this flag revealed a typo in a test that I also fixed.

In addition to this change, I also addressed other minor build issues: 

- removed a call to ``consider_setuptools_entrypoints()`` in setup.py
- pinned test requirements to latest version.
- added ``setuptools>=17.1`` to satisfy ``mock`` requirement.

Fixes #37
@pdpinch @bdero 