### PR TITLE
Updated post_grades() to send raw score and max points

### DIFF
--- a/lmod_proxy/edx_grades/actions.py
+++ b/lmod_proxy/edx_grades/actions.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 """Actions to perform based on API request.
 """
-import csv
 import logging
 
 from flask import render_template, current_app
@@ -34,7 +33,7 @@ def post_grades(gradebook, form):
         # Create assignment to explicitly set max points.
         assignment, max_points = _get_assignment_name_max_points(form)
         gradebook.create_assignment(
-            assignment,
+            assignment[0:3] + assignment[-2:],
             assignment,
             1.0,
             max_points,
@@ -134,10 +133,9 @@ def get_sections(gradebook, form):
 
 def _get_assignment_name_max_points(form):
     try:
-        csv_file = form.datafile.data.stream
-        reader = csv.reader(csv_file)
-        short_name = reader.next()[1]
-        max_points = reader.next()[2]
+        csv_data = form.datafile.data.stream.read()
+        short_name = csv_data[0][1]
+        max_points = csv_data[1][2]
         return short_name, max_points
-    finally:
-        csv_file.close()
+    except IOError:
+        raise

--- a/lmod_proxy/tests/test_edx_grades.py
+++ b/lmod_proxy/tests/test_edx_grades.py
@@ -16,7 +16,9 @@ class TestEdXGrades(CommonTest):
     FULL_FORM = dict(
         gradebook='test_gradebook',
         user='user@example.com',
-        datafile='a,b,c',
+        datafile=[
+            ['External email', 'Multiple Choice Questions', 'max_pts'],
+            ['staff@example.com', '2.0', '3.0']],
         section='test_section',
         submit='get-membership'
     )
@@ -94,7 +96,7 @@ class TestEdXGrades(CommonTest):
             headers=headers
         )
         self.assertEqual(200, response.status_code)
-        log.info.assert_assert_called_with(
+        log.info.assert_called_with(
             'edX remote gradebook GET request from %s',
             'abc'
         )

--- a/lmod_proxy/tests/test_edx_grades.py
+++ b/lmod_proxy/tests/test_edx_grades.py
@@ -86,7 +86,7 @@ class TestEdXGrades(CommonTest):
             for key, item in form.data.items():
                 self.assertEqual(self.FULL_FORM[key], item)
 
-    @mock.patch('lmod_proxy.edx_grades.log')
+    @mock.patch('lmod_proxy.edx_grades.log', autospec=True)
     def test_get_root(self, log):
         """Test the GET response returns what we want"""
         headers = self.get_basic_auth_headers()
@@ -121,7 +121,7 @@ class TestEdXGrades(CommonTest):
             }
         )
 
-    @mock.patch('lmod_proxy.edx_grades.GradeBook')
+    @mock.patch('lmod_proxy.edx_grades.GradeBook', autospec=True)
     def test_post_actions(self, patched_gradebook):
         """Verify that we call the right functions with each action type"""
         local_form = copy.deepcopy(self.FULL_FORM)
@@ -229,7 +229,7 @@ class TestEdXGrades(CommonTest):
         self.assertEqual(message, 'test')
         self.assertEqual(data, [{}])
 
-    @mock.patch('lmod_proxy.edx_grades.actions.log')
+    @mock.patch('lmod_proxy.edx_grades.actions.log', autospec=True)
     def test_post_grades(self, mock_log):
         """Test post_grades actions as expected"""
         from lmod_proxy.edx_grades.forms import EdXGradesForm
@@ -276,7 +276,8 @@ class TestEdXGrades(CommonTest):
 
         with self.app.app_context():
             with mock.patch(
-                    'lmod_proxy.edx_grades.actions.render_template'
+                    'lmod_proxy.edx_grades.actions.render_template',
+                    autospec=True
             ) as mock_template:
                 message, data, success = post_grades(gradebook, form)
 

--- a/lmod_proxy/tests/test_module.py
+++ b/lmod_proxy/tests/test_module.py
@@ -29,13 +29,16 @@ class TestModule(unittest.TestCase):
 
         error_string = 'Please install this project with setup.py'
 
-        with mock.patch('lmod_proxy.get_distribution') as mock_distribution:
+        with mock.patch(
+                'lmod_proxy.get_distribution',
+                autospec=True
+        ) as mock_distribution:
             # Test with distribution not found:
             mock_distribution.side_effect = DistributionNotFound()
             self.assertEqual(_get_version(), error_string)
 
         # Test with loc path not matching
-        with mock.patch('os.path.abspath') as mock_path:
+        with mock.patch('os.path.abspath', autospec=True) as mock_path:
             mock_path.return_value = 'not/where/we/are'
             self.assertEqual(_get_version(), error_string)
             # Bonus regression test to make sure we are calling

--- a/lmod_proxy/tests/test_web.py
+++ b/lmod_proxy/tests/test_web.py
@@ -46,7 +46,7 @@ class TestWeb(CommonTest):
         imp.reload(lmod_proxy.config)
         import lmod_proxy.web
 
-        with mock.patch('lmod_proxy.web.log') as patch_log:
+        with mock.patch('lmod_proxy.web.log', autospec=True) as patch_log:
             local_app = lmod_proxy.web.app_factory()
             self.assertTrue(patch_log.critical.called)
             self.assertEqual(

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ flask-log==0.1.0
 passlib==1.6.2
 pylmod==0.1.0
 PyYAML==3.11
+setuptools>=17.1
 uwsgi==2.0.10
- 
+
 -e .

--- a/setup.py
+++ b/setup.py
@@ -43,10 +43,6 @@ class PyTest(testcommand):
         import pytest
         # Needed in order for pytest_cache to load properly
         # Alternate fix: import pytest_cache and pass to pytest.main
-        import _pytest.config
-
-        pm = _pytest.config.get_plugin_manager()
-        pm.consider_setuptools_entrypoints()
         errno = pytest.main(self.test_args)
         sys.exit(errno)
 

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,8 +1,9 @@
-pytest-cov>=1.8.0
-pytest-pep8>=1.0.6,
-pytest-flakes>=0.2,
-pytest>=2.6.3,
-pyflakes>=0.8.1,
-pytest-cache>=1.0,
-semantic_version>=2.3.1
-mock>=1.0.1
+mock==1.0.1
+pyflakes==0.8.1
+pytest-cache==1.0
+pytest-cov==1.8.0
+pytest-flakes==0.2
+pytest-pep8==1.0.6
+pytest==2.6.4
+semantic_version==2.3.1
+setuptools>=17.1


### PR DESCRIPTION
It is more useful for course staff if the remote gradebook
    is sent the student's raw score for an assignment and the
    assignment contains the maximum points allowable.  edX now
    sends raw score and maximum points allowed in its CSV file.
    ``post_grades()`` now explicitly creates the assignment, assigning
    the maximum points value and then sends the data.

Fixes #36

@pdpinch