### PR TITLE
Pin setuptools to version before 20.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ flask-log==0.1.0
 passlib==1.6.2
 pylmod==0.1.0
 PyYAML==3.11
-setuptools>=17.1
+setuptools==20.1.1
 uwsgi==2.0.10
 
 -e .


### PR DESCRIPTION
I pinned the setuptools version to 20.1.1 because the problem arises in [20.2](https://pythonhosted.org/setuptools/history.html#id4).
This problem with the test requirements in PyLmod will be fixed next release.