### PR TITLE
Wrapping file stream in TextIOWrapper due to bytes vs string bug

### DIFF
--- a/lmod_proxy/edx_grades/actions.py
+++ b/lmod_proxy/edx_grades/actions.py
@@ -2,6 +2,7 @@
 """Actions to perform based on API request.
 """
 import logging
+from io import TextIOWrapper
 
 from flask import render_template, current_app
 from requests.exceptions import RequestException
@@ -24,7 +25,7 @@ def post_grades(gradebook, form):
     approve_grades = False
     if current_app.config['LMODP_APPROVE_GRADES']:
         approve_grades = True
-    csv_file = form.datafile.data.stream
+    csv_file = TextIOWrapper(form.datafile.data.stream, encoding='utf8')
     log.debug('Received grade CSV: %s', csv_file.read())
     # Seek back to 0 for future reading
     csv_file.seek(0)

--- a/lmod_proxy/tests/test_edx_grades.py
+++ b/lmod_proxy/tests/test_edx_grades.py
@@ -2,9 +2,11 @@
 """Unit testing for the edx_grades blueprint"""
 import copy
 import json
+import io
 
 import unittest.mock as mock
 from pylmod.exceptions import PyLmodException
+from werkzeug.datastructures import FileStorage
 
 from lmod_proxy.edx_grades import edx_grades
 from lmod_proxy.edx_grades.forms import EdXGradesForm, ACTIONS
@@ -229,9 +231,10 @@ class TestEdXGrades(CommonTest):
         """Test post_grades actions as expected"""
 
         file_form = copy.deepcopy(self.FULL_FORM)
-        file_mock = mock.MagicMock()
-        file_mock.stream.read.return_value = file_form['datafile']
-        file_form['datafile'] = file_mock
+        file_form['datafile'] = FileStorage(
+            stream=io.BytesIO(file_form['datafile'].encode('utf8')),
+            filename='testfile.csv',
+            content_type='text/csv')
         with self.app.app_context():
             form = EdXGradesForm(**file_form)
         gradebook = mock.MagicMock()
@@ -290,9 +293,10 @@ class TestEdXGrades(CommonTest):
     def test_post_grades_approve(self):
         """Validate that approve grades works"""
         file_form = copy.deepcopy(self.FULL_FORM)
-        file_mock = mock.MagicMock()
-        file_mock.stream.read.return_value = file_form['datafile']
-        file_form['datafile'] = file_mock
+        file_form['datafile'] = FileStorage(
+            stream=io.BytesIO(file_form['datafile'].encode('utf8')),
+            filename='testfile.csv',
+            content_type='text/csv')
 
         with self.app.app_context():
             form = EdXGradesForm(**file_form)
@@ -315,9 +319,10 @@ class TestEdXGrades(CommonTest):
     def test_max_points(self):
         """Validate max points arguments"""
         file_form = copy.deepcopy(self.FULL_FORM)
-        file_mock = mock.MagicMock()
-        file_mock.stream.read.return_value = file_form['datafile']
-        file_form['datafile'] = file_mock
+        file_form['datafile'] = FileStorage(
+            stream=io.BytesIO(file_form['datafile'].encode('utf8')),
+            filename='testfile.csv',
+            content_type='text/csv')
 
         with self.app.app_context():
             form = EdXGradesForm(**file_form)


### PR DESCRIPTION
When reading the file stream in PyLMod it was throwing an error about the stream being bytes instead of strings. Wrapping in TextIOWrapper allows for treating the stream as utf8 text.
